### PR TITLE
migrate from MeshPolicy to PeerAuthentication

### DIFF
--- a/cluster/mesh-policy.yaml
+++ b/cluster/mesh-policy.yaml
@@ -1,9 +1,0 @@
-apiVersion: "authentication.istio.io/v1alpha1"
-kind: "MeshPolicy"
-metadata:
-  name: "default"
-spec:
-  peers:
-  - mtls:
-      mode: PERMISSIVE
-

--- a/namespaces/istio-system/peer-authentication.yaml
+++ b/namespaces/istio-system/peer-authentication.yaml
@@ -1,0 +1,8 @@
+apiVersion: "security.istio.io/v1beta1"
+kind: "PeerAuthentication"
+metadata:
+  name: "default"
+  namespace: "istio-system"
+spec:
+  mtls:
+    mode: PERMISSIVE


### PR DESCRIPTION
Migrate from MeshPolicy to PeerAuthentication, to support ASM 1.6

Reference: https://cloud.google.com/service-mesh/docs/security/update-authentication-policies