### PR TITLE
reduce cpu request to accommodate smaller clusters

### DIFF
--- a/namespaces/onlineboutique/k8s-manifest.yaml
+++ b/namespaces/onlineboutique/k8s-manifest.yaml
@@ -52,7 +52,7 @@ spec:
             command: ["/bin/grpc_health_probe", "-addr=:8080"]
         resources:
           requests:
-            cpu: 30m
+            cpu: 10m
             memory: 64Mi
           limits:
             cpu: 200m
@@ -120,7 +120,7 @@ spec:
           #   value: "jaeger-collector:14268"
           resources:
             requests:
-              cpu: 30m
+              cpu: 10m
               memory: 64Mi
             limits:
               cpu: 200m
@@ -179,7 +179,7 @@ spec:
           value: "False"
         resources:
           requests:
-            cpu: 30m
+            cpu: 10m
             memory: 220Mi
           limits:
             cpu: 200m
@@ -260,7 +260,7 @@ spec:
           #   value: "jaeger-collector:14268"
           resources:
             requests:
-              cpu: 30m
+              cpu: 10m
               memory: 64Mi
             limits:
               cpu: 200m
@@ -309,7 +309,7 @@ spec:
             command: ["/bin/grpc_health_probe", "-addr=:50051"]
         resources:
           requests:
-            cpu: 30m
+            cpu: 10m
             memory: 64Mi
           limits:
             cpu: 200m
@@ -367,7 +367,7 @@ spec:
             command: ["/bin/grpc_health_probe", "-addr=:3550"]
         resources:
           requests:
-            cpu: 30m
+            cpu: 10m
             memory: 64Mi
           limits:
             cpu: 200m
@@ -414,7 +414,7 @@ spec:
           value: "0.0.0.0"
         resources:
           requests:
-            cpu: 50m
+            cpu: 15m
             memory: 64Mi
           limits:
             cpu: 300m
@@ -470,7 +470,7 @@ spec:
           value: "3"
         resources:
           requests:
-            cpu: 30m
+            cpu: 10m
             memory: 128Mi
           limits:
             cpu: 200m
@@ -513,7 +513,7 @@ spec:
             command: ["/bin/grpc_health_probe", "-addr=:7000"]
         resources:
           requests:
-            cpu: 30m
+            cpu: 10m
             memory: 64Mi
           limits:
             cpu: 200m
@@ -570,7 +570,7 @@ spec:
             command: ["/bin/grpc_health_probe", "-addr=:50051"]
         resources:
           requests:
-            cpu: 30m
+            cpu: 10m
             memory: 64Mi
           limits:
             cpu: 200m
@@ -623,7 +623,7 @@ spec:
             memory: 256Mi
             cpu: 125m
           requests:
-            cpu: 20m
+            cpu: 10m
             memory: 200Mi
       volumes:
       - name: redis-data
@@ -672,7 +672,7 @@ spec:
         #  value: "jaeger-collector:14268"
         resources:
           requests:
-            cpu: 40m
+            cpu: 15m
             memory: 180Mi
           limits:
             cpu: 300m


### PR DESCRIPTION
In order to reduce the footprint of ASD to support projects with <=8vCPU quota, we are looking into changing ASD to a single cluster deployment with 3 x 2 vCPU nodes. The current resource requests can fit into 3 x 2 vCPU nodes. This change is to allow the deployment to be scheduled on 2 x 2vCPU nodes too in case 1 node is down in the case of disaster or cluster upgrade. 

Below is some data to support that it can actually run on 2 x 2vCPU nodes. 
```
$ kubectl top pods -n onlineboutique
NAME                                     CPU(cores)   MEMORY(bytes)   
adservice-6b9f9667fc-4gmsk               27m          135Mi           
cartservice-7b4ffc8f7c-mj95b             12m          83Mi            
currencyservice-5b69f47d-25wm5           18m          69Mi            
emailservice-797bd8568b-ht4xx            10m          77Mi            
frontend-57d689bc7f-f6k4j                26m          56Mi            
loadgenerator-77f9869746-gzdzt           10m          65Mi            
loadgenerator-77f9869746-jqmlz           10m          65Mi            
paymentservice-75d69db68b-9qbsp          7m           69Mi            
productcatalogservice-57bb7dc6f8-m4q4j   19m          54Mi            
recommendationservice-747f574f54-49jhh   18m          77Mi            
redis-cart-b5595fdd-x9j2p                6m           36Mi            
shippingservice-cdc6655dc-wgm5t          13m          52Mi            
shoppingcartservice-768dd5479-x4px2      7m           51Mi            
$ kubectl top nodes
NAME                                                  CPU(cores)   CPU%   MEMORY(bytes)   MEMORY%   
gke-anthos-sample-cluste-default-pool-985835d2-79vg   528m         27%    2145Mi          35%       
gke-anthos-sample-cluste-default-pool-985835d2-hfh3   513m         26%    1879Mi          31%     
```
![image](https://user-images.githubusercontent.com/2538581/87308473-df6f7a00-c54d-11ea-94c9-65d9746c97d6.png)
